### PR TITLE
API Token config caching updates.

### DIFF
--- a/cmd/api_tokens_init.go
+++ b/cmd/api_tokens_init.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/provideservices/provide-go"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var apiTokensInitCmd = &cobra.Command{
@@ -27,6 +28,10 @@ func createAPIToken(cmd *cobra.Command, args []string) {
 	}
 	if status == 201 {
 		apiToken := resp.(map[string]interface{})
+		if viper.Get(apiTokenConfigKey) == nil {
+			viper.Set(apiTokenConfigKey, apiToken["token"])
+			viper.WriteConfig()
+		}
 		fmt.Printf("API Token\t%s\n", apiToken["token"])
 	} else {
 		fmt.Printf("Failed to create API token; %s", resp)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,12 @@ var verbose bool
 var networkID string
 var applicationID string
 
+const (
+	// Note: Viper downcases key names, so hyphenating for better readability.
+	authTokenConfigKey = "auth-token"
+	apiTokenConfigKey  = "api-token"
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "prvd",
 	Short: "Provide command-line interface",
@@ -63,6 +69,8 @@ func initConfig() {
 				err = viper.WriteConfigAs(configPath)
 			}
 		}
+
+		viper.RegisterAlias(authTokenConfigKey, "token")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
@@ -78,7 +86,7 @@ func initConfig() {
 }
 
 func requireAPIToken() string {
-	token := viper.Get("token")
+	token := viper.Get(authTokenConfigKey)
 	if token == nil {
 		log.Printf("Authorized API token required in prvd configuration; have you authenticated or otherwise configured an API token?")
 		os.Exit(1)


### PR DESCRIPTION
- Saving newly created token to config file if one was not already there.
- We will make the config/cache more comprehensive later; keeping it simple for now.
- Also started using constants for the config keys.
- And changed auth token key name for better clarity in the face of other token types; aliased old value, as well.