### PR TITLE
Wallet flag for dapps

### DIFF
--- a/cmd/api_tokens_init.go
+++ b/cmd/api_tokens_init.go
@@ -28,7 +28,7 @@ func createAPIToken(cmd *cobra.Command, args []string) {
 	}
 	if status == 201 {
 		apiToken := resp.(map[string]interface{})
-		appAPITokenKey := buildConfigKeyWithApp(apiTokenConfigKeyPrefix, applicationID)
+		appAPITokenKey := buildConfigKeyWithApp(apiTokenConfigKeyPartial, applicationID)
 		if !viper.IsSet(appAPITokenKey) {
 			viper.Set(appAPITokenKey, apiToken["token"])
 			viper.WriteConfig()

--- a/cmd/api_tokens_init.go
+++ b/cmd/api_tokens_init.go
@@ -19,7 +19,7 @@ var apiTokensInitCmd = &cobra.Command{
 
 // createAPIToken triggers the generation of an API token for the given network.
 func createAPIToken(cmd *cobra.Command, args []string) {
-	token := requireAPIToken()
+	token := requireUserAuthToken()
 	params := map[string]interface{}{}
 	status, resp, err := provide.CreateApplicationToken(token, applicationID, params)
 	if err != nil {
@@ -28,8 +28,9 @@ func createAPIToken(cmd *cobra.Command, args []string) {
 	}
 	if status == 201 {
 		apiToken := resp.(map[string]interface{})
-		if viper.Get(apiTokenConfigKey) == nil {
-			viper.Set(apiTokenConfigKey, apiToken["token"])
+		appAPITokenKey := buildConfigKeyWithApp(apiTokenConfigKeyPrefix, applicationID)
+		if !viper.IsSet(appAPITokenKey) {
+			viper.Set(appAPITokenKey, apiToken["token"])
 			viper.WriteConfig()
 		}
 		fmt.Printf("API Token\t%s\n", apiToken["token"])

--- a/cmd/authenticate.go
+++ b/cmd/authenticate.go
@@ -78,6 +78,6 @@ func doPasswordPrompt() string {
 }
 
 func cacheAPIToken(token string) {
-	viper.Set("token", token)
+	viper.Set(authTokenConfigKey, token)
 	viper.WriteConfig()
 }

--- a/cmd/dapps_init.go
+++ b/cmd/dapps_init.go
@@ -41,7 +41,7 @@ func createApplication(cmd *cobra.Command, args []string) {
 	if status == 201 {
 		dapp := resp.(map[string]interface{})
 		applicationID = dapp["id"].(string)
-		result := fmt.Sprintf("%s\t%s\n", dapp["id"], dapp["name"])
+		result := fmt.Sprintf("%s\t%s\n", dapp["name"], dapp["id"])
 		fmt.Print(result)
 	}
 	if !withoutAPIToken {

--- a/cmd/dapps_init.go
+++ b/cmd/dapps_init.go
@@ -12,6 +12,7 @@ import (
 
 var dappName string
 var withoutAPIToken bool
+var withoutWallet bool
 
 var dappsInitCmd = &cobra.Command{
 	Use:   "init --name 'my awesome dapp' --network 024ff1ef-7369-4dee-969c-1918c6edb5d4",
@@ -21,6 +22,10 @@ var dappsInitCmd = &cobra.Command{
 }
 
 func createApplication(cmd *cobra.Command, args []string) {
+	if withoutAPIToken && !withoutWallet {
+		fmt.Println("Cannot create an application that has a wallet but no API token.")
+		os.Exit(1)
+	}
 	token := requireAPIToken()
 	params := map[string]interface{}{
 		"name": dappName,
@@ -42,6 +47,9 @@ func createApplication(cmd *cobra.Command, args []string) {
 	if !withoutAPIToken {
 		createAPIToken(cmd, args)
 	}
+	if !withoutWallet {
+		createWallet(cmd, args)
+	}
 }
 
 func init() {
@@ -52,4 +60,5 @@ func init() {
 	dappsInitCmd.MarkFlagRequired("network")
 
 	dappsInitCmd.Flags().BoolVar(&withoutAPIToken, "without-api-token", false, "do not create a new API token for this dapp")
+	dappsInitCmd.Flags().BoolVar(&withoutWallet, "without-wallet", false, "do not create a new wallet (signing identity) for this dapp")
 }

--- a/cmd/dapps_list.go
+++ b/cmd/dapps_list.go
@@ -27,7 +27,7 @@ func listApplications(cmd *cobra.Command, args []string) {
 	}
 	for i := range resp.([]interface{}) {
 		dapp := resp.([]interface{})[i].(map[string]interface{})
-		result := fmt.Sprintf("%s\t%s\n", dapp["id"], dapp["name"])
+		result := fmt.Sprintf("%s\t%s\n", dapp["name"], dapp["id"])
 		fmt.Print(result)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ const (
 	// and NOT used by themselves.
 	authTokenConfigKey       = "auth-token" // user-scoped API token key
 	apiTokenConfigKeyPartial = "api-token"  // app-scoped API token key
+	walletConfigKeyPartial   = "wallet"     // app-scoped wallet ID key
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,9 +17,11 @@ var networkID string
 var applicationID string
 
 const (
-	// Note: Viper downcases key names, so hyphenating for better readability.
-	authTokenConfigKey      = "auth-token" // user-scoped API token key
-	apiTokenConfigKeyPrefix = "api-token"  // app-scoped API token key prefix
+	// Viper downcases key names, so hyphenating for better readability.
+	// 'Partial' keys are to be combined with the application ID they are associated with.
+	// and NOT used by themselves.
+	authTokenConfigKey       = "auth-token" // user-scoped API token key
+	apiTokenConfigKeyPartial = "api-token"  // app-scoped API token key
 )
 
 var rootCmd = &cobra.Command{
@@ -71,8 +73,6 @@ func initConfig() {
 				err = viper.WriteConfigAs(configPath)
 			}
 		}
-
-		viper.RegisterAlias(authTokenConfigKey, "token")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
@@ -104,7 +104,7 @@ func requireAPIToken() string {
 	token := ""
 	appAPITokenKey := ""
 	if applicationID != "" {
-		appAPITokenKey = buildConfigKeyWithApp(apiTokenConfigKeyPrefix, applicationID)
+		appAPITokenKey = buildConfigKeyWithApp(apiTokenConfigKeyPartial, applicationID)
 	}
 	if viper.IsSet(appAPITokenKey) {
 		token = viper.GetString(appAPITokenKey)
@@ -119,14 +119,14 @@ func requireAPIToken() string {
 	return token
 }
 
-// buildConfigKeyWithApp combines the given prefix and app ID according to a consistent convention.
+// buildConfigKeyWithApp combines the given key partial and app ID according to a consistent convention.
 // Returns an empty string if the given appID is empty.
 // Viper's getters likewise return empty strings when passed an empty string.
-func buildConfigKeyWithApp(keyPrefix, appID string) string {
+func buildConfigKeyWithApp(keyPartial, appID string) string {
 	if appID == "" {
 		// Development-time debugging.
 		log.Println("An application identifier is required for this operation")
 		return ""
 	}
-	return fmt.Sprintf("%s.%s", keyPrefix, appID)
+	return fmt.Sprintf("%s.%s", appID, keyPartial)
 }

--- a/cmd/wallets_init.go
+++ b/cmd/wallets_init.go
@@ -72,9 +72,9 @@ func createManagedWallet() {
 	}
 	if status == 201 {
 		wallet := resp.(map[string]interface{})
-		result := fmt.Sprintf("%s\t%s\n", wallet["id"], wallet["address"])
+		result := fmt.Sprintf("Wallet %s\t%s\n", wallet["id"], wallet["address"])
 		if name, nameOk := wallet["name"].(string); nameOk {
-			result = fmt.Sprintf("%s\t%s - %s\n", wallet["id"], name, wallet["address"])
+			result = fmt.Sprintf("Wallet %s\t%s - %s\n", name, wallet["id"], wallet["address"])
 		}
 		appWalletKey := buildConfigKeyWithApp(walletConfigKeyPartial, applicationID)
 		if !viper.IsSet(appWalletKey) {

--- a/cmd/wallets_list.go
+++ b/cmd/wallets_list.go
@@ -28,7 +28,7 @@ func listWallets(cmd *cobra.Command, args []string) {
 		wallet := resp.([]interface{})[i].(map[string]interface{})
 		result := fmt.Sprintf("%s\t%s\n", wallet["id"], wallet["address"])
 		if name, nameOk := wallet["name"].(string); nameOk {
-			result = fmt.Sprintf("%s\t%s - %s\n", wallet["id"], name, wallet["address"])
+			result = fmt.Sprintf("%s\t%s - %s\n", name, wallet["id"], wallet["address"])
 		}
 		fmt.Print(result)
 	}


### PR DESCRIPTION
Now wallet signing identities are created when dapps are initialized - with a flag to opt-out on a case-by-case basis. 

Also includes changes to the format of the config file and modifications to the console output, among other smaller tweaks. 
