### PR TITLE
Issue 18: Top-level commands menu handling

### DIFF
--- a/prvd/common/prompt.go
+++ b/prvd/common/prompt.go
@@ -64,9 +64,10 @@ func CmdExists(cmd *cobra.Command, args []string) (bool, string) {
 }
 
 func CmdExistsOrExit(cmd *cobra.Command, args []string) {
-	exists, command := CmdExists(cmd, args)
+	exists, _ := CmdExists(cmd, args)
 	if !exists {
-		fmt.Printf("%s is not a valid command", command)
+		// if command doesn't exist, try to execute help
+		cmd.Help()
 		os.Exit(1)
 	}
 }

--- a/prvd/common/prompt.go
+++ b/prvd/common/prompt.go
@@ -66,7 +66,7 @@ func CmdExists(cmd *cobra.Command, args []string) (bool, string) {
 func CmdExistsOrExit(cmd *cobra.Command, args []string) {
 	exists, _ := CmdExists(cmd, args)
 	if !exists {
-		// if command doesn't exist, try to execute help
+		// if command doesn't exist, execute help
 		cmd.Help()
 		os.Exit(1)
 	}


### PR DESCRIPTION
Issue: https://github.com/provideplatform/provide-cli/issues/18

Solution:
Instead of printing that command is not found, execute help command. This way if command doesn't exist it will execute either help of that command or parent command. Tested with:
```
prvd accounts
prvd accounts non-existant-subcommand
prvd non-existant-command
```
